### PR TITLE
✨ Add Persistence Directory Configuration Option

### DIFF
--- a/src/memorious_mcp/main.py
+++ b/src/memorious_mcp/main.py
@@ -9,13 +9,13 @@ from fastmcp import FastMCP, Context
 from .backends.chroma_backend import ChromaMemoryBackend
 
 
-def build_mcp(collection_name: str = "memories") -> FastMCP:
+def build_mcp(collection_name: str = "memories", persist_directory: Optional[str] = None) -> FastMCP:
     """
     Build a FastMCP server instance and register store/recall/forget tools.
     """
     mcp = FastMCP("MemoriousMCP")
     # attach a MemoryStore instance to the server for tool implementations
-    memory = ChromaMemoryBackend(collection_name=collection_name)
+    memory = ChromaMemoryBackend(collection_name=collection_name, persist_directory=persist_directory)
 
     @mcp.tool
     async def store(key: str, value: str, ctx: Optional[Context] = None):
@@ -117,11 +117,13 @@ def build_mcp(collection_name: str = "memories") -> FastMCP:
 def main():
     parser = argparse.ArgumentParser("mcp-memory-stdio-server")
     parser.add_argument("--collection", default="memories", help="ChromaDB collection name to use")
+    parser.add_argument("--persist-directory", default=None, help="Directory where ChromaDB will persist data (defaults to ./.memorious)")
     args = parser.parse_args()
 
-    mcp = build_mcp(collection_name=args.collection)
+    mcp = build_mcp(collection_name=args.collection, persist_directory=args.persist_directory)
 
-    print("Starting FastMCP stdio MCP server using collection '%s'" % args.collection)
+    persist_dir = args.persist_directory or "./.memorious"
+    print("Starting FastMCP stdio MCP server using collection '%s' with persistence in '%s'" % (args.collection, persist_dir))
     # Default transport is STDIO for FastMCP; run the server and accept MCP stdio calls
     mcp.run()
 


### PR DESCRIPTION
## Summary

This PR adds a configurable persistence directory option to the MemoriousMCP server, allowing users to specify where ChromaDB will persist data instead of using the default location.

## Key Features

- **Persistence Directory Parameter**: Added  parameter to  function
- **CLI Argument Support**: New  command-line argument for easy configuration
- **Enhanced Logging**: Updated server startup message to display the persistence directory being used

## Technical Details

### Changes Made
- Updated  function signature to accept optional  parameter
- Modified  initialization to pass through the persistence directory
- Enhanced argument parser with  option
- Improved server startup logging to show both collection name and persistence directory

### Implementation
- Maintains backward compatibility with existing usage
- Defaults to  directory when no custom path is specified
- Clean parameter passing from CLI through to backend initialization

## Changes Summary

**Files Modified**: 1
- : Enhanced with persistence directory configuration

**Lines Changed**: +6/-4

## Testing

- [ ] Verify server starts with default persistence directory
- [ ] Test custom persistence directory via  flag
- [ ] Confirm backward compatibility with existing configurations
- [ ] Validate that ChromaDB correctly uses the specified directory

## Review Notes

This change enhances the flexibility of the MemoriousMCP server by allowing users to control where their memory data is persisted. The implementation maintains full backward compatibility while adding the new configuration option through both programmatic and CLI interfaces.

The change is focused and minimal, affecting only the necessary components to add this functionality without disrupting existing behavior.